### PR TITLE
Fix address parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ serve
 serve -d '/opt/webpage'
 
 # current directory port 8081
-serve -a '8081'
+serve -a ':8081'
 
 # current directory localhost access only port 8082
 serve -a '127.0.0.1:8082'

--- a/main.go
+++ b/main.go
@@ -20,9 +20,10 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
-	"github.com/urfave/cli"
 	"github.com/gorilla/handlers"
+	"github.com/urfave/cli"
 )
 
 func main() {
@@ -64,6 +65,9 @@ func main() {
 		}
 		if c.String("address") != "" {
 			address = c.String("address")
+		}
+		if !strings.Contains(address, ":") {
+			address = ":" + address
 		}
 		server := handlers.CompressHandler(http.FileServer(http.Dir(dir)))
 		if c.Bool("log") {


### PR DESCRIPTION
## Summary
- handle addresses lacking a colon so `-a 8081` works
- correct README example for listening on port 8081

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go build ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68532886289c8320bf0b6f8266631a36