### PR TITLE
Remove redundant default value assignments

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,15 +56,8 @@ func main() {
 		},
 	}
 	app.Action = func(c *cli.Context) error {
-		address := ":8080"
-		dir := "."
-
-		if c.String("dir") != "" {
-			dir = c.String("dir")
-		}
-		if c.String("address") != "" {
-			address = c.String("address")
-		}
+		dir := c.String("dir")
+		address := c.String("address")
 		server := handlers.CompressHandler(http.FileServer(http.Dir(dir)))
 		if c.Bool("log") {
 			server = handlers.LoggingHandler(os.Stderr, server)


### PR DESCRIPTION
The CLI flag definitions already specify default values for 'dir' and 'address'. The action function was redundantly re-checking and assigning these defaults. Since c.String() returns the flag's default value when not explicitly set, the conditional checks are unnecessary.