### PR TITLE
Replace deprecated GitHub Actions with gh CLI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,15 +5,15 @@ on:
     branches:
       - main
     tags:
-      - 'v*.*.*'          # run on vX.Y.Z tag pushes
+      - 'v*.*.*'
   pull_request:
     branches:
       - main
 
 permissions:
-  id-token: write        # for OIDC / Sigstore attestations
-  contents: write        # to create Releases & upload assets  [oai_citation:0‡Stack Overflow](https://stackoverflow.com/questions/67389957/what-permissions-does-github-token-require-for-releases-from-a-github-action?utm_source=chatgpt.com)
-  attestations: write    # for Provenance attestations
+  id-token: write
+  contents: write
+  attestations: write
 
 jobs:
   build:
@@ -44,46 +44,19 @@ jobs:
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: './serve'
-        # this action writes the attestation to a temp file and exposes its path
-        # in `steps.attest.outputs.bundle-path`  [oai_citation:1‡GitHub](https://github.com/actions/attest-build-provenance?utm_source=chatgpt.com)
-
-      # Create & upload a GitHub Release only on a pushed tag
-      - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/create-release@v1
-        id: create_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}    # authenticate API calls  [oai_citation:2‡GitHub](https://github.com/actions/create-release?utm_source=chatgpt.com)
-        with:
-          tag_name: ${{ github.ref_name }}
-          release_name: Release ${{ github.ref_name }}
-          body: |
-            - Built with Go ${{ matrix.go-version }}
-            - Provenance attested
 
       - name: Copy attestation JSON
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           cp "${{ steps.attest.outputs.bundle-path }}" ./serve.intoto.json
 
-      - name: Upload binary to release
+      - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./serve
-          asset_name: serve
-          asset_content_type: application/octet-stream
-
-      - name: Upload attestation file
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./serve.intoto.json
-          asset_name: serve.intoto.json
-          asset_content_type: application/json
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} \
+            serve serve.intoto.json \
+            --title "Release ${{ github.ref_name }}" \
+            --notes "- Built with Go ${{ matrix.go-version }}
+          - Provenance attested"


### PR DESCRIPTION
- Replace actions/create-release@v1 and actions/upload-release-asset@v1 with GitHub CLI (gh release create)
- Uses first-party GitHub tooling instead of third-party actions
- Simplifies workflow by combining release creation and asset upload
- Remove citation links from comments