### PR TITLE
Add golangci-lint to CI workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+
+      - name: Run linter
+        run: golangci-lint run
+
       - name: Build binary
         run: go build -v -o serve .
 


### PR DESCRIPTION
Adds linting step before build to catch code quality issues early. Uses go install to fetch golangci-lint directly, avoiding third-party GitHub Actions.