### PR TITLE
Add version string with build-time injection

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,7 +46,12 @@ jobs:
         run: go test -v ./...
 
       - name: Build binary
-        run: go build -v -o serve .
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            VERSION="${GITHUB_SHA::8}"
+          fi
+          go build -v -ldflags="-X main.version=${VERSION}" -o serve .
 
       - name: Generate artifact attestation
         id: attest

--- a/main.go
+++ b/main.go
@@ -29,10 +29,14 @@ import (
 	"github.com/urfave/cli"
 )
 
+// version is set at build time via ldflags
+var version = "dev"
+
 func main() {
 	app := cli.NewApp()
 	app.Name = "serve"
 	app.Usage = "Simple HTTP Server"
+	app.Version = version
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "dir, d",


### PR DESCRIPTION
- Add version variable that can be set via ldflags at build time
- Set app.Version so --version flag works properly
- Update CI to inject version from git tag or commit SHA
- Default to "dev" for local builds